### PR TITLE
Uninstall_install multiple packages at once

### DIFF
--- a/Public/Packages/Install-ChocoPackage.ps1
+++ b/Public/Packages/Install-ChocoPackage.ps1
@@ -7,7 +7,7 @@ Function Install-ChocoPackage {
         Installs a chocolatey package. Doesn't asks for confirmation by default. Just like Chocolatey, you may need admin rights to install a package.
 
     .PARAMETER Name
-        The name of the package to install.
+        The name of the package to install. You can specify more than one package.
 
     .PARAMETER Source
         The source to install the package from.
@@ -17,6 +17,9 @@ Function Install-ChocoPackage {
 
     .PARAMETER Force
         Will force the reinstallation of the package.
+
+    .PARAMETER AskForConfirmation
+        Ask for confirmation before uninstalling the package.
 
     .EXAMPLE
         Install-ChocoPackage -Name vlc
@@ -30,49 +33,68 @@ Function Install-ChocoPackage {
     #>
     [OutputType([PSCustomObject])]
     param(
-        [Parameter(Mandatory = $true, Position = 0)]
-        [String] $Name,
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipelineByPropertyName = $true)]
+        [String[]] $Name,
         [String] $Source = "chocolatey",
         [Switch] $Upgrade = $false,
-        [Switch] $Force = $false
+        [Switch] $Force = $false,
+        [Switch] $AskForConfirmation
+
     )
 
-    if (Test-ChocoInstalled) {
+    begin {
+        if (-Not (Test-ChocoInstalled)) {
+            Write-Error "Chocolatey is not installed. Please install it first."
+            return
+        }
 
         if ($Upgrade) {
-            [String[]]$Arguments += "upgrade", "-y"
-        }
-        elseif ($Force) {
-            [String[]]$Arguments += "install", "--force", "-y"
-        }
-        else {
-            [String[]]$Arguments += "install", "-y"
+            [String[]]$Arguments = "upgrade"
+        } else {
+            [String[]]$Arguments = "install"
         }
 
-        $Arguments += $Name, "--source", $Source
-
-        $CommandOutput = Invoke-ChocoCommand $Arguments
-        if ($CommandOutput.Status -eq "Success") {
-            if ($CommandOutput.RawOutput -like "*already installed.*") {
-
-                $Status = "Already installed"
-
-            }
-            elseif ($CommandOutput.RawOutput -like "*The install of $Name was successful*") {
-                $Status = "Installed"
-
-            }
-            $Version = (Get-ChocoPackage $Name).Version
+        if ($Force) {
+            $Arguments += "--force"
         }
 
-        Return [PSCustomObject]@{
-            Name    = $Name
-            Status  = $Status
-            Version = $Version
+        if (-Not ($AskForConfirmation)) {
+            $Arguments += "-y"
         }
-
     }
-    else {
-        Write-Error "Chocolatey is not installed. Please install it first."
+
+    process {
+
+        $Arguments += "--source", $Source
+
+        foreach ($package in $Name) {
+
+            $CommandOutput = Invoke-ChocoCommand ($Arguments + $package)
+
+            if ($CommandOutput.Status -eq "Success") {
+                if ($CommandOutput.RawOutput -like "*already installed.*") {
+
+                    $Status = "Already installed"
+
+                }
+                elseif ($CommandOutput.RawOutput -like "*The install of $package was successful*") {
+                    $Status = "Installed"
+
+                }
+                $Version = (Get-ChocoPackage $package).Version
+            } else {
+                $Status = "Error"
+            }
+
+            [PSCustomObject]@{
+                Name   = $package
+                Status = $Status
+                Version = $Version
+            }
+        }
+    }
+
+    end {
+
     }
 }


### PR DESCRIPTION
- Relates to #15 

These changes make passing multiple package names at once to `Uninstall-ChocoPackage` and `Install-ChocoPackage` possible.
It could be implemented in other functions as well.

The basic change for this is simple:
Change the parameter `[String] $Name` to `[String[]] $Name` and loop through it to install or uninstall packages.

I moved `Invoke-ChocoCmd` to the `process {}`-block for better output handling when the package name array comes from a pipeline input. This way you get a result for every single package you try to install or uninstall and can write this result back to the output.

You *could* use `Invoke-ChocoCmd` in the `end {}`-block but `choco.exe` would be called like this:

``` powershell
choco <options> install|uninstall firefox vlc gimp etcher <and so on>
```
but you won't get accurate results for every package installation/uninstallation.

The loop in `process {}` might be a bit slower (Invoking `choco.exe` multiple times takes more time than calling it once with multiple package names) but IMHO this approach is better for getting the results you want.

The `end {}`-block is therefore not used here and can be left empty.

I also adapted the basic structure of `Uninstall-ChocoPackage` for `Install-ChocoPackage`. It looked more advanced in handling the parameters and the way they are passed to choco. I hope this was okay.


