### PR TITLE
Implemented search for all packages available on a source

### DIFF
--- a/ChocoMan.psd1
+++ b/ChocoMan.psd1
@@ -12,7 +12,7 @@
     RootModule        = '.\ChocoMan.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.9.0'
+    ModuleVersion     = '0.10.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Docs/Search-ChocoPackage.md
+++ b/Docs/Search-ChocoPackage.md
@@ -9,15 +9,17 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Search for a chocolatey package.
+Returns all packages if no name is specified.
 
 ## SYNTAX
 
 ```
-Search-ChocoPackage [-Name] <String> [-Source <String>] [-Exact] [<CommonParameters>]
+Search-ChocoPackage [[-Name] <String>] [-Source <String>] [-Exact] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 Search for a chocolatey package.
+Returns all packages if no name specified.
 
 ## EXAMPLES
 
@@ -51,6 +53,15 @@ Name Version
 vlc  3.0.18
 ```
 
+Search-ChocoPackage
+Name                Version
+----                -------
+vlc                 3.0.18
+vlc.install         3.0.18
+...                 ...
+...                 ...
+```
+
 ## PARAMETERS
 
 ### -Exact
@@ -76,7 +87,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 1
 Default value: None
 Accept pipeline input: False

--- a/Public/Packages/Search-ChocoPackage.ps1
+++ b/Public/Packages/Search-ChocoPackage.ps1
@@ -1,13 +1,13 @@
 Function Search-ChocoPackage {
     <#
     .SYNOPSIS
-        Search for a chocolatey package.
+        Search for a chocolatey package. If no name is specified this will return all available packages.
     .DESCRIPTION
-        Search for a chocolatey package.
+        Search for a chocolatey package.  If no name is specified this will return all available packages.
     .PARAMETER Name
-        The name of the package to search for.
+        The name of the package to search for. Omit to return all available packages.
     .PARAMETER Source
-        Search on a specific source.
+        Search on a specific source. Defaults to the official Chocolatey repository.
     .PARAMETER Exact
         Search for an exact match.
 
@@ -28,11 +28,22 @@ Function Search-ChocoPackage {
         vlc.install         3.0.18
         vlc.portable        3.0.18
         vlc-nightly         4.0.0.20230713
+
     .EXAMPLE
         Search-ChocoPackage -Name "vlc" -Source "chocolatey" -Exact
         Name Version
         ---- -------
         vlc  3.0.18
+
+    .EXAMPLE
+        Search-ChocoPackage
+        Name                Version
+        ----                -------
+        vlc                 3.0.18
+        vlc.install         3.0.18
+        ...                 ...
+        ...                 ...
+
     .OUTPUTS
         PSCustomObject
 
@@ -40,9 +51,8 @@ Function Search-ChocoPackage {
     [CmdletBinding()]
     [OutputType([PSCustomObject])]
     param(
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Position = 0)]
         [String] $Name,
-
         [String] $Source = "chocolatey",
         [Switch] $Exact
     )


### PR DESCRIPTION
This commit enhances the Search-ChocoPackage function so the name parameter is no longer required thereby permitting a search that can return all available packages on a source. The documentation for the Search-ChocoPackage function was updated accordingly, making it clearer and more informative for users.

- Update Search-ChocoPackage.ps1 function Name parameter so it is not required
- Improve Search-ChocoPackage.md documentation by clarifying that it returns all packages if no name is specified.
- Update Search-ChocoPackage.ps1 function description to mention that it returns all available packages if no name is specified.
- Update Search-ChocoPackage.ps1 function parameter Name description to mention that omitting the parameter will return all available packages.
- Update Search-ChocoPackage.ps1 function example in the documentation to demonstrate returning all available packages when no name is specified.
- Update ChocoMan.psd1 ModuleVersion from 0.9.0 to 0.10.0.

Note: Commit Message generated in part by AI